### PR TITLE
Removed auth path

### DIFF
--- a/libs/AccessToken.js
+++ b/libs/AccessToken.js
@@ -7,7 +7,7 @@ class AccessToken {
   }
 
   async info (accessToken) {
-    const response = await this.request.get(`/auth/realms/${this.config.realm}/protocol/openid-connect/userinfo`, {
+    const response = await this.request.get(`/realms/${this.config.realm}/protocol/openid-connect/userinfo`, {
       headers: {
         Authorization: 'Bearer ' + accessToken
       }
@@ -19,7 +19,7 @@ class AccessToken {
   refresh (refreshToken) {
     const cfg = this.config
 
-    return this.request.post(`/auth/realms/${cfg.realm}/protocol/openid-connect/token`, qs.stringify({
+    return this.request.post(`/realms/${cfg.realm}/protocol/openid-connect/token`, qs.stringify({
       grant_type: 'refresh_token',
       client_id: cfg.client_id,
       client_secret: cfg.client_secret,
@@ -31,7 +31,7 @@ class AccessToken {
     const cfg = this.config
 
     if (!this.data) {
-      const response = await this.request.post(`/auth/realms/${cfg.realm}/protocol/openid-connect/token`, qs.stringify({
+      const response = await this.request.post(`/realms/${cfg.realm}/protocol/openid-connect/token`, qs.stringify({
         grant_type: 'password',
         username: cfg.username,
         password: cfg.password,

--- a/libs/Jwt.js
+++ b/libs/Jwt.js
@@ -23,7 +23,7 @@ class Jwt {
   }
 
   async verify (accessToken) {
-    await this.request.get(`/auth/realms/${this.config.realm}/protocol/openid-connect/userinfo`, {
+    await this.request.get(`/realms/${this.config.realm}/protocol/openid-connect/userinfo`, {
       headers: {
         Authorization: 'Bearer ' + accessToken
       }

--- a/libs/UserManager.js
+++ b/libs/UserManager.js
@@ -6,7 +6,7 @@ class UserManager {
   }
 
   async details (id) {
-    const response = await this.request.get(`/auth/admin/realms/${this.config.realm}/users/${id}`, {
+    const response = await this.request.get(`/admin/realms/${this.config.realm}/users/${id}`, {
       headers: {
         Authorization: 'Bearer ' + await this.token.get()
       }
@@ -21,7 +21,7 @@ class UserManager {
 
     // retrieve roles from each target client
     clients.forEach(async cid => promises.push(this.request
-      .get(`/auth/admin/realms/${this.config.realm}/users/${id}/role-mappings/clients/${cid}/composite`, {
+      .get(`/admin/realms/${this.config.realm}/users/${id}/role-mappings/clients/${cid}/composite`, {
         headers: {
           Authorization: 'Bearer ' + accessToken
         }
@@ -29,7 +29,7 @@ class UserManager {
     // retrieve roles from realm
     if (includeRealmRoles) {
       promises.push(this.request
-        .get(`/auth/admin/realms/${this.config.realm}/users/${id}/role-mappings/realm/composite`, {
+        .get(`/admin/realms/${this.config.realm}/users/${id}/role-mappings/realm/composite`, {
           headers: {
             Authorization: 'Bearer ' + accessToken
           }


### PR DESCRIPTION
Newer versions of keycloak now have different hostnames for admin console and frontend endpoints (see https://www.keycloak.org/server/hostname), so auth path in url is now deprecated and shouldn't be hardcoded at package if we want to use it. Anyway if someone is still using an older version of keycloak he can simply configure the url with /auth at the end so he can also use the library.