### PR TITLE
Improve Types for Token's Content and make it available

### DIFF
--- a/libs/Token.ts
+++ b/libs/Token.ts
@@ -1,28 +1,85 @@
-import { decode } from 'jsonwebtoken'
+import {decode} from 'jsonwebtoken'
+
+export interface TokenContent {
+    [key: string]: any,
+
+    /**
+     * Authorization server’s identifier
+     */
+    iss: string,
+
+    /**
+     * User’s identifier
+     */
+    sub: string,
+
+    /**
+     * Client’s identifier
+     */
+    aud: string | string[],
+
+    /**
+     * Expiration time of the ID token
+     */
+    exp: number,
+
+    /**
+     * Time at which JWT was issued
+     */
+    iat: number,
+
+    family_name?: string,
+    given_name?: string,
+    name?: string,
+    email?: string,
+    preferred_username?: string,
+    email_verified?: boolean,
+
+
+}
 
 export class Token {
-  private readonly token: string
-  private readonly content: any
+    public readonly token: string
+    public readonly content: TokenContent
 
-  constructor (token: string) {
-    this.token = token
-    this.content = decode(this.token)
-  }
-
-  isExpired (): boolean {
-    return (this.content.exp * 1000) <= Date.now()
-  }
-
-  hasApplicationRole (appName: string, roleName: string): boolean {
-    const appRoles = this.content.resource_access[appName]
-    if (appRoles == null) {
-      return false
+    constructor(token: string) {
+        this.token = token
+        const jwtPayload = decode(this.token, {json: true});
+        if (
+            jwtPayload !== null &&
+            jwtPayload.iss !== undefined &&
+            jwtPayload.sub !== undefined &&
+            jwtPayload.aud !== undefined &&
+            jwtPayload.exp !== undefined &&
+            jwtPayload.iat !== undefined
+        ) {
+            this.content = {
+                ...jwtPayload,
+                iss: jwtPayload.iss,
+                sub: jwtPayload.sub,
+                aud: jwtPayload.aud,
+                exp: jwtPayload.exp,
+                iat: jwtPayload.iat,
+            }
+        } else {
+            throw new Error('Invalid token');
+        }
     }
 
-    return (appRoles.roles.indexOf(roleName) >= 0)
-  }
+    isExpired(): boolean {
+        return (this.content.exp * 1000) <= Date.now()
+    }
 
-  hasRealmRole (roleName: string): boolean {
-    return (this.content.realm_access.roles.indexOf(roleName) >= 0)
-  }
+    hasApplicationRole(appName: string, roleName: string): boolean {
+        const appRoles = this.content.resource_access[appName]
+        if (appRoles == null) {
+            return false
+        }
+
+        return (appRoles.roles.indexOf(roleName) >= 0)
+    }
+
+    hasRealmRole(roleName: string): boolean {
+        return (this.content.realm_access.roles.indexOf(roleName) >= 0)
+    }
 }

--- a/libs/Token.ts
+++ b/libs/Token.ts
@@ -1,6 +1,6 @@
 import { decode } from 'jsonwebtoken'
 
-export interface TokenContent {
+export interface ITokenContent {
     [key: string]: any,
 
     /**
@@ -40,7 +40,7 @@ export interface TokenContent {
 
 export class Token {
     public readonly token: string
-    public readonly content: TokenContent
+    public readonly content: ITokenContent
 
     constructor(token: string) {
         this.token = token

--- a/libs/Token.ts
+++ b/libs/Token.ts
@@ -1,4 +1,4 @@
-import {decode} from 'jsonwebtoken'
+import { decode } from 'jsonwebtoken'
 
 export interface TokenContent {
     [key: string]: any,


### PR DESCRIPTION
For a current project I need to be able to read data like name and email from the contents of the token. But said content is currently marked as private in the Token class. 
So firstly I would like to propose to make it public (I honestly don't remember any reason why I made it private in the first place when I proposed the typescript migration).
Secondly I  created a type for the the content. I made the properties that are required for openid connect [[1]](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) mandatory, added some common properties like name and email as optional properties and a `[key: string]: any` so that unknown properties are also allowed.

[1] [https://openid.net/specs/openid-connect-core-1_0.html#IDToken](https://openid.net/specs/openid-connect-core-1_0.html#IDToken)